### PR TITLE
Added Update PSCAT in Main Menu

### DIFF
--- a/Scripts/MainMenu.ps1
+++ b/Scripts/MainMenu.ps1
@@ -148,7 +148,7 @@ class MainMenu
         if ($showOptionWebpage)
         {
             [CommonCUI]::DrawMenuItem('H', `
-                                    "Access the project's, $([ProjectInformation]::GetProjectName()), webpage", `
+                                    "Access the project's, $([ProjectInformation]::GetProjectName()), webpage.", `
                                     [ProjectInformation]::GetProjectWebsite(), `
                                     $NULL, `
                                     $true);
@@ -173,7 +173,7 @@ class MainMenu
 
         # Help Documentation
         [CommonCUI]::DrawMenuItem('?', `
-                                "Help Documentation", `
+                                "Help documentation", `
                                 "Access the $($GLOBAL:_PROGRAMNAMESHORT_) Wiki documentation online.", `
                                 $NULL, `
                                 $true);

--- a/Scripts/MainMenu.ps1
+++ b/Scripts/MainMenu.ps1
@@ -163,6 +163,14 @@ class MainMenu
                                 $true);
 
 
+        # Update Program
+        [CommonCUI]::DrawMenuItem('U', `
+                                "Check for $($GLOBAL:_PROGRAMNAME_) updates.", `
+                                $GLOBAL:_PROGRAMSITEDOWNLOADS_, `
+                                $NULL, `
+                                $true);
+
+
         # Help Documentation
         [CommonCUI]::DrawMenuItem('?', `
                                 "Help Documentation", `
@@ -286,6 +294,26 @@ class MainMenu
                 # Finished
                 break;
             } # Load Project into Program
+
+
+            # Check for program updates
+            {($_ -eq "U") -or `
+                ($_ -eq "Update") -or `
+                ($_ -eq "Update $($GLOBAL:_PROGRAMNAME_)") -or `
+                ($_ -eq "Update $($GLOBAL:_PROGRAMNAMESHORT_)")}
+            {
+                # Initiate the Update Protocol
+                if (![WebsiteResources]::AccessWebSite_Update($GLOBAL:_PROGRAMSITEDOWNLOADS_, `         # Program's Release Page
+                                                            "$($GLOBAL:_PROGRAMNAME_) Update Page"))    # Show Page Title
+                {
+                    # Alert the user that the web functionality did not successfully work as intended.
+                    [NotificationAudible]::Notify([NotificationAudibleEventType]::Error);
+                } # if : Failed to Open Webpage
+
+
+                # Finished
+                break;
+            } # Update Program
 
 
             # Access the Program's Help Documentation


### PR DESCRIPTION
Readded the ability for the user to check for program updates through the Main Menu.  This was removed back in commit https://github.com/SibTiger/PowerShell-Compact-Archive-Tool/commit/5c24948549e88bda9dabf8b136667af9b8375711, because the Check for Updates was relocated to the Settings Main Menu - - which was ultimately removed in commit https://github.com/SibTiger/PowerShell-Compact-Archive-Tool/commit/de770757163817ce9e964a7058bf3b09df3e0e7a

#129 